### PR TITLE
Update packages (package is used by ex-generic, for legacy configs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 
 script:
   - ./vendor/bin/phpcs --standard=psr2 --ignore=vendor -n .
-  - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml --whitelist=src/
+  - XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml --whitelist=src/
 
 after_success:
   - "./vendor/bin/test-reporter --stdout > codeclimate.json"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.0
+  - 7.4
 
 before_install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require-dev": {
         "phpunit/phpunit": "^5.2",
         "codeclimate/php-test-reporter": "dev-master",
-        "squizlabs/php_codesniffer": "2.5*"
+        "squizlabs/php_codesniffer": "^2.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         }
     ],
     "require": {
-		"keboola/php-csvtable": "~0.1.0",
-		"keboola/php-utils": "^2.1",
-		"monolog/monolog": "~1.8",
-		"php": ">=5.4.0"
+		"keboola/php-csvtable": "^1.1",
+		"keboola/php-utils": "^4.1",
+		"monolog/monolog": "^2.2",
+		"php": ">=7.4"
     },
 	"require-dev": {
         "phpunit/phpunit": "^5.2",
         "codeclimate/php-test-reporter": "dev-master",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.5*"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/KeboolaLegacy/Json/Parser.php
+++ b/src/KeboolaLegacy/Json/Parser.php
@@ -456,9 +456,10 @@ class Parser
 
         $safeType = $this->createSafeName($type);
         if (empty($this->csvFiles[$safeType])) {
-            $this->csvFiles[$safeType] = Table::create(
+            $this->csvFiles[$safeType] = new Table(
                 $safeType,
                 $this->headers[$type],
+                true,
                 $this->getTemp()
             );
             $this->csvFiles[$safeType]->addAttributes(["fullDisplayName" => $type]);

--- a/tests/KeboolaLegacy/Json/ParserTest.php
+++ b/tests/KeboolaLegacy/Json/ParserTest.php
@@ -32,7 +32,7 @@ class ParserTest extends ParserTestCase
             "0",
             str_getcsv(
                 file(
-                    $parser->getCsvFiles()['entities_hashtags_indices']
+                    $parser->getCsvFiles()['entities_hashtags_indices']->getPathName()
                 )[1] // 2nd row
             )[0] // 1st column
         );
@@ -55,7 +55,7 @@ class ParserTest extends ParserTestCase
         self::assertEquals('id,date', $parser->getCsvFiles()['root']->getPrimaryKey());
         self::assertEquals(
             '"stuff","root_1;2015-10-21"' . PHP_EOL,
-            file($parser->getCsvFiles()['root_data'])[1]
+            file($parser->getCsvFiles()['root_data']->getPathName())[1]
         );
     }
 
@@ -330,7 +330,7 @@ class ParserTest extends ParserTestCase
                 '"string"' . PHP_EOL,
                 '"1"' . PHP_EOL // true gets converted to "1"! should be documented!
             ],
-            file($parser->getCsvFiles()['threepack']->getPathname())
+            file($parser->getCsvFiles()['threepack']->getPathName())
         );
     }
 
@@ -387,7 +387,7 @@ class ParserTest extends ParserTestCase
         );
         self::assertEquals(
             file_get_contents($this->getDataDir() . 'ParentIdsTest.csv'),
-            file_get_contents($parser->getCsvFiles()['test'])
+            file_get_contents($parser->getCsvFiles()['test']->getPathName())
         );
     }
 
@@ -401,7 +401,7 @@ class ParserTest extends ParserTestCase
                 '"a"' . PHP_EOL,
                 '"b"' . PHP_EOL,
             ],
-            file($parser->getCsvFiles()['root']->getPathname())
+            file($parser->getCsvFiles()['root']->getPathName())
         );
     }
 
@@ -457,7 +457,7 @@ class ParserTest extends ParserTestCase
         );
         self::assertEquals(
             file_get_contents($this->getDataDir() . 'NestedArraysJson.csv'),
-            file_get_contents($parser->getCsvFiles()['root'])
+            file_get_contents($parser->getCsvFiles()['root']->getPathName())
         );
     }
 
@@ -484,7 +484,7 @@ class ParserTest extends ParserTestCase
         self::assertEquals(
             '"id","KeywordRanking_attributes_date","KeywordRanking_stuff_I_ARE_POTAT","KeywordRanking_stuff_kek_ser_ou_ly"' . PHP_EOL .
             '"123456","2015-03-20","aaa$@!","now"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['root'])
+            file_get_contents($parser->getCsvFiles()['root']->getPathName())
         );
     }
 
@@ -572,7 +572,7 @@ class ParserTest extends ParserTestCase
             '"root_eae48f50d1159c41f633f876d6c66411"' . PHP_EOL .
             '"root_83cb9491934903381f6808ac79842022"' . PHP_EOL .
             '"root_6d231f9592a4e259452229e2be31f42e"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['root'])
+            file_get_contents($parser->getCsvFiles()['root']->getPathName())
         );
 
         self::assertEquals(
@@ -581,7 +581,7 @@ class ParserTest extends ParserTestCase
             '"val2.1.1","val2.1.2","root_83cb9491934903381f6808ac79842022"' . PHP_EOL .
             '"val2.2.1","","root_83cb9491934903381f6808ac79842022"' . PHP_EOL .
             '"val3.1","val3.2","root_6d231f9592a4e259452229e2be31f42e"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['root_key'])
+            file_get_contents($parser->getCsvFiles()['root_key']->getPathName())
         );
 
         // Test with array first
@@ -612,7 +612,7 @@ class ParserTest extends ParserTestCase
             '"key"' . PHP_EOL .
             '"arr_d03523e758a12366bd7062ee727c4939"' . PHP_EOL .
             '"arr_6d231f9592a4e259452229e2be31f42e"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['arr'])
+            file_get_contents($parser->getCsvFiles()['arr']->getPathName())
         );
 
         self::assertEquals(
@@ -620,7 +620,7 @@ class ParserTest extends ParserTestCase
             '"val2.1.1","val2.1.2","arr_d03523e758a12366bd7062ee727c4939"' . PHP_EOL .
             '"val2.2.1","val2.2.2","arr_d03523e758a12366bd7062ee727c4939"' . PHP_EOL .
             '"val3.1","val3.2","arr_6d231f9592a4e259452229e2be31f42e"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['arr_key'])
+            file_get_contents($parser->getCsvFiles()['arr_key']->getPathName())
         );
     }
 
@@ -723,7 +723,7 @@ class ParserTest extends ParserTestCase
             '"root_0c616a2609bd2e8d88574f3f856170c5"' . PHP_EOL .
             '"root_3cc17a87c69e64707ac357e84e5a9eb8"' . PHP_EOL .
             '"root_af523454cc66582ad5dcec3f171b35ed"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['root'])
+            file_get_contents($parser->getCsvFiles()['root']->getPathName())
         );
 
         self::assertEquals(
@@ -732,7 +732,7 @@ class ParserTest extends ParserTestCase
             '"str2.1","root_3cc17a87c69e64707ac357e84e5a9eb8"' . PHP_EOL .
             '"str2.2","root_3cc17a87c69e64707ac357e84e5a9eb8"' . PHP_EOL .
             '"str3","root_af523454cc66582ad5dcec3f171b35ed"' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['root_key'])
+            file_get_contents($parser->getCsvFiles()['root_key']->getPathName())
         );
     }
 
@@ -752,7 +752,7 @@ class ParserTest extends ParserTestCase
         self::assertEquals(
             '"id","value"' . PHP_EOL .
             '"1",""' . PHP_EOL,
-            file_get_contents($parser->getCsvFiles()['root'])
+            file_get_contents($parser->getCsvFiles()['root']->getPathName())
         );
     }
 
@@ -816,7 +816,7 @@ class ParserTest extends ParserTestCase
             '"s2null_eb89917794221aeda822735efbab9069","s2null_eb89917794221aeda822735efbab9069"' . PHP_EOL .
             '"s2null_77cca534224f13ec1fa45c6c0c98557d","s2null_77cca534224f13ec1fa45c6c0c98557d"' . PHP_EOL .
             '',
-            file_get_contents($parser->getCsvFiles()['s2null'])
+            file_get_contents($parser->getCsvFiles()['s2null']->getPathName())
         );
 
         self::assertEquals(
@@ -824,7 +824,7 @@ class ParserTest extends ParserTestCase
             '"stringArr","s2null_eb89917794221aeda822735efbab9069"' . PHP_EOL .
             '"","s2null_77cca534224f13ec1fa45c6c0c98557d"' . PHP_EOL .
             '',
-            file_get_contents($parser->getCsvFiles()['s2null_val'])
+            file_get_contents($parser->getCsvFiles()['s2null_val']->getPathName())
         );
 
         self::assertEquals(
@@ -832,7 +832,7 @@ class ParserTest extends ParserTestCase
             '"objValue","s2null_eb89917794221aeda822735efbab9069"' . PHP_EOL .
             '"","s2null_77cca534224f13ec1fa45c6c0c98557d"' . PHP_EOL .
             '',
-            file_get_contents($parser->getCsvFiles()['s2null_obj'])
+            file_get_contents($parser->getCsvFiles()['s2null_obj']->getPathName())
         );
 
         self::assertEquals(
@@ -840,7 +840,7 @@ class ParserTest extends ParserTestCase
             '"null2s_eb89917794221aeda822735efbab9069","null2s_eb89917794221aeda822735efbab9069"' . PHP_EOL .
             '"null2s_77cca534224f13ec1fa45c6c0c98557d","null2s_77cca534224f13ec1fa45c6c0c98557d"' . PHP_EOL .
             '',
-            file_get_contents($parser->getCsvFiles()['null2s'])
+            file_get_contents($parser->getCsvFiles()['null2s']->getPathName())
         );
 
         self::assertEquals(
@@ -848,7 +848,7 @@ class ParserTest extends ParserTestCase
             '"stringArr","null2s_eb89917794221aeda822735efbab9069"' . PHP_EOL .
             '"","null2s_77cca534224f13ec1fa45c6c0c98557d"' . PHP_EOL .
             '',
-            file_get_contents($parser->getCsvFiles()['null2s_val'])
+            file_get_contents($parser->getCsvFiles()['null2s_val']->getPathName())
         );
 
         self::assertEquals(
@@ -856,7 +856,7 @@ class ParserTest extends ParserTestCase
             '"objValue","null2s_eb89917794221aeda822735efbab9069"' . PHP_EOL .
             '"","null2s_77cca534224f13ec1fa45c6c0c98557d"' . PHP_EOL .
             '',
-            file_get_contents($parser->getCsvFiles()['null2s_obj'])
+            file_get_contents($parser->getCsvFiles()['null2s_obj']->getPathName())
         );
     }
 

--- a/tests/KeboolaLegacy/Json/RealDataTest.php
+++ b/tests/KeboolaLegacy/Json/RealDataTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace KeboolaLegacy\Json;
 
+use Keboola\Csv\CsvReader;
 use KeboolaLegacy\Json\Test\ParserTestCase;
 
 class RealDataTest extends ParserTestCase
@@ -23,7 +24,8 @@ class RealDataTest extends ParserTestCase
             );
 
             // compare column counts
-            $parsedFile = file($table->getPathname());
+            $headerCount = null;
+            $parsedFile = new CsvReader($table->getPathname());
             foreach ($parsedFile as $row) {
                 if (empty($headerCount)) {
                     $headerCount = count($row);
@@ -89,7 +91,7 @@ class RealDataTest extends ParserTestCase
 
         // -1 offset to compensate for header
         $rows = -1;
-        $handle = fopen($parser->getCsvFiles()['root_statuses'], 'r');
+        $handle = fopen($parser->getCsvFiles()['root_statuses']->getPathName(), 'r');
         while (fgetcsv($handle)) {
             $rows++;
         }
@@ -212,7 +214,8 @@ class RealDataTest extends ParserTestCase
             );
 
             // compare column counts
-            $parsedFile = file($table->getPathname());
+            $headerCount = null;
+            $parsedFile = new CsvReader($table->getPathname());
             foreach ($parsedFile as $row) {
                 if (empty($headerCount)) {
                     $headerCount = count($row);
@@ -245,6 +248,6 @@ class RealDataTest extends ParserTestCase
             '"ag-forecastio","",""' . PHP_EOL .
             '"rcp-distribution-groups","1","1"' . PHP_EOL;
 
-        self::assertEquals($result, file_get_contents($parser->getCsvFiles()['root']));
+        self::assertEquals($result, file_get_contents($parser->getCsvFiles()['root']->getPathName()));
     }
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-596

Tento balicek je deprecated: https://packagist.org/packages/keboola-legacy/json-parser
Ale `juicer` ho pouziva pre legacy konfiguracie: https://github.com/keboola/juicer/blob/a373256e9077d27f8cd405cea323679d12dd3eb8/src/Parser/Json.php#L50
Takze som tu musel spravit aspon nevyhnutny update.